### PR TITLE
Fix double class in same namespace

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -19,7 +19,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.4</version>
+    <version>1.4.1</version>
     <author>
         <name>Benjamin Perche</name>
         <email>bperche9@gmail.com</email>

--- a/Resources/Event/Base/__TABLE__Events.php
+++ b/Resources/Event/Base/__TABLE__Events.php
@@ -3,7 +3,7 @@
 
 namespace {$moduleCode}\Event\Base;
 
-use {$moduleCode}\Event\{$moduleCode}Events;
+use {$moduleCode}\Event\{$moduleCode}Events as Child{$moduleCode}Events;
 
 /*
  * Class {$table->getTableName()}Events
@@ -12,13 +12,13 @@ use {$moduleCode}\Event\{$moduleCode}Events;
  */
 class {$table->getTableName()}Events
 {
-    const CREATE = {$moduleCode}Events::{$table->getUppercaseName()}_CREATE;
-    const UPDATE = {$moduleCode}Events::{$table->getUppercaseName()}_UPDATE;
-    const DELETE = {$moduleCode}Events::{$table->getUppercaseName()}_DELETE;
+    const CREATE = Child{$moduleCode}Events::{$table->getUppercaseName()}_CREATE;
+    const UPDATE = Child{$moduleCode}Events::{$table->getUppercaseName()}_UPDATE;
+    const DELETE = Child{$moduleCode}Events::{$table->getUppercaseName()}_DELETE;
 {if $table->hasPosition()}
-    const UPDATE_POSITION = {$moduleCode}Events::{$table->getUppercaseName()}_UPDATE_POSITION;
+    const UPDATE_POSITION = Child{$moduleCode}Events::{$table->getUppercaseName()}_UPDATE_POSITION;
 {/if}
 {if $table->hasVisible()}
-    const TOGGLE_VISIBILITY = {$moduleCode}Events::{$table->getUppercaseName()}_TOGGLE_VISIBILITY;
+    const TOGGLE_VISIBILITY = Child{$moduleCode}Events::{$table->getUppercaseName()}_TOGGLE_VISIBILITY;
 {/if}
 }


### PR DESCRIPTION
Hello,

Fix double class in same namespace

Exemple module Library: 

```
- Event
-- Base
--- LibraryEvents
--- BookEvents
```

``` php
namespace Library\Event\Base;

use Library\Event\LibraryEvents; // class LibraryEvents is already present in namespace Library\Event\Base

class BookEvents
{
 ........

```

Cheers neighbor,
